### PR TITLE
Fix file header line to use three hyphens for proper ELPA compatibility.

### DIFF
--- a/http-twiddle.el
+++ b/http-twiddle.el
@@ -1,4 +1,4 @@
-;;; http-twiddle.el -- send & twiddle & resend HTTP requests
+;;; http-twiddle.el --- send & twiddle & resend HTTP requests
 
 ;; This program belongs to the public domain.
 


### PR DESCRIPTION
Note that `M-: (package-buffer-info)` can be used to check whether a
file's comments and headers comply with the ELPA requirements.
