### PR TITLE
Fix setting buffer local variable

### DIFF
--- a/http-twiddle.el
+++ b/http-twiddle.el
@@ -123,7 +123,7 @@ is substituted with the evaluated value formatted as string."
 
   (let ((content (buffer-string)))
     (with-temp-buffer
-      (set (make-variable-buffer-local 'font-lock-keywords)
+      (set (make-local-variable 'font-lock-keywords)
            http-twiddle-font-lock-keywords)
       (insert content)
       (http-twiddle-expand-template)


### PR DESCRIPTION
In this case, make-local-variable shoudl be used. `make-variable-buffer-local` should be used only at toplevel. (And there is following byte-compile warning).

```
http-twiddle.el:128:15:Warning: `make-variable-buffer-local' not called at
    toplevel
```